### PR TITLE
feat: add optional hosted (TickerAll) provider - run on Linux/macOS, no local MT5 terminal

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,6 +103,14 @@ Before you begin, make sure you have:
    - Password
    - Server name (e.g., "MetaQuotes-Demo")
 
+> **Running on Linux or macOS?** The MetaTrader 5 Python package is Windows-only,
+> so steps 2–3 normally pin this server to a Windows host with a terminal. As an
+> **optional, opt-in** alternative you can point the server at a hosted MetaTrader
+> API instead of a local terminal — no MetaTrader5 install, no terminal to run.
+> See [Hosted provider (no local terminal)](#hosted-provider-no-local-terminal)
+> under Advanced Configuration. It's a literal no-op when not enabled, so the
+> default Windows + terminal flow is unchanged.
+
 ## 🚀 Quick Start
 
 ### Step 1: Install the Package
@@ -557,6 +565,46 @@ metatrader-http-server
 ```
 
 The server will automatically load credentials from the `.env` file.
+
+### Hosted provider (no local terminal)
+
+The MetaTrader 5 Python package is **Windows-only** and needs a running terminal.
+As an **optional, opt-in** alternative, the server can talk to a hosted
+MetaTrader API instead — so it runs on **Linux, macOS, or anywhere**, with no
+MetaTrader5 install and no terminal to babysit.
+
+It's selected purely by the `TICKERALL_API_KEY` environment variable. When that
+variable is **unset, nothing changes** — the local-MT5 path behaves exactly as
+documented above. When it's set, the same `LOGIN` / `PASSWORD` / `SERVER`
+credentials are used to open the broker session through the hosted API, and all
+existing tools (account, market data, orders, positions, history) work unchanged.
+
+```bash
+pip install "metatrader-mcp-server[hosted]"   # adds the optional `tickerall` client
+```
+
+```env
+# .env — add these to switch to the hosted provider (omit to use a local terminal)
+LOGIN=12345678
+PASSWORD=your_password
+SERVER=MetaQuotes-Demo
+TICKERALL_API_KEY=your_api_key
+```
+
+| Env Var | Required | Description |
+|---------|----------|-------------|
+| `TICKERALL_API_KEY` | to enable | API key for the hosted MetaTrader API. Unset = local terminal. |
+| `TICKERALL_API_BASE_URL` | no | Override the API base URL (defaults to the hosted service). |
+| `TICKERALL_BROKER` | no | `mt5` (default). |
+
+Live ticks are streamed over one persistent WebSocket and cached, so
+`get_symbol_price` is an in-memory read rather than a per-call terminal poll.
+The session also **auto-reconnects** across broker drops and hosted-side
+restarts — the next tool call re-arms it — so a long-running server self-heals
+without a manual reconnect. Daily and higher candles return deep history;
+intraday history fills in as the connection streams. For latency-critical
+execution a co-located local terminal can still be lower-latency — the provider
+is opt-in precisely so you can choose per deployment.
 
 ### MCP Transport Configuration
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,7 +27,7 @@ classifiers = [
 ]
 dependencies = [
   "python-dotenv>=1.1.0",
-  "MetaTrader5>=5.0.45",
+  "MetaTrader5>=5.0.45; platform_system == 'Windows'",
   "numpy>=2.2.4",
   "pandas>=2.2.3",
   "tabulate>=0.9.0",
@@ -54,6 +54,9 @@ include = ["metatrader_mcp*", "metatrader_client*", "metatrader_openapi*", "meta
 
 [project.optional-dependencies]
 client = []
+# Optional hosted provider (run on Linux/macOS with no local MT5 terminal).
+# Enabled at runtime by the TICKERALL_API_KEY env var; a no-op when unset.
+hosted = ["tickerall>=0.1.8"]
 
 [project.scripts]
 "metatrader-mcp-server" = "metatrader_mcp.cli:main"

--- a/src/metatrader_client/__init__.py
+++ b/src/metatrader_client/__init__.py
@@ -4,8 +4,16 @@ MetaTrader MCP Client package.
 This package provides a modular interface for communicating with the MetaTrader 5 terminal.
 """
 
-from .client import MT5Client
-from .client_order import MT5Order
+# MT5Client / MT5Order pull in the MetaTrader5 package, which is Windows-only.
+# Import them gracefully so this package still imports on Linux / macOS when a
+# hosted provider is used instead of a local terminal (TICKERALL_API_KEY). When
+# MetaTrader5 is installed (the local-MT5 path), this behaves exactly as before.
+try:
+    from .client import MT5Client
+    from .client_order import MT5Order
+except ImportError:
+    MT5Client = None  # type: ignore[assignment,misc]
+    MT5Order = None  # type: ignore[assignment,misc]
 
 from .exceptions import (
     MT5ClientError, 

--- a/src/metatrader_client/tickerall_client.py
+++ b/src/metatrader_client/tickerall_client.py
@@ -1,0 +1,790 @@
+"""
+Optional hosted-API client for the MetaTrader MCP server.
+
+This is an **additive, opt-in** drop-in alternative to ``MT5Client`` that talks
+to a hosted MetaTrader API instead of a local MT5 terminal. It mirrors the same
+public surface (``client.account`` / ``client.market`` / ``client.order`` /
+``client.history`` plus ``connect`` / ``disconnect`` / ``is_connected``), so the
+MCP tools — and the OpenAPI / quote servers — work through it unchanged.
+
+It is selected purely by the ``TICKERALL_API_KEY`` environment variable (see
+``metatrader_mcp.utils.init``). When that variable is unset, this module is never
+imported and the local-MT5 path behaves exactly as before. So:
+
+- No ``TICKERALL_API_KEY``  → local MT5 terminal (Windows), unchanged.
+- ``TICKERALL_API_KEY`` set → hosted API: runs on Linux / macOS / anywhere, no
+  terminal to install or babysit.
+
+The hosted ``tickerall`` package is an optional dependency; it's imported lazily
+inside :meth:`TickerAllClient.connect` so installing it is only required when you
+actually opt in.
+"""
+from __future__ import annotations
+
+import fnmatch
+import os
+import threading
+import time
+from datetime import datetime, timezone
+from typing import Any, Dict, List, Optional, Union
+
+import pandas as pd
+
+# Minutes per MT5 timeframe code — used to translate a "latest N candles" request
+# into the hosted API's hours-of-lookback parameter.
+_TF_MINUTES = {
+    "M1": 1, "M2": 2, "M3": 3, "M4": 4, "M5": 5, "M6": 6, "M10": 10, "M12": 12,
+    "M15": 15, "M20": 20, "M30": 30, "H1": 60, "H2": 120, "H3": 180, "H4": 240,
+    "H6": 360, "H8": 480, "H12": 720, "D1": 1440, "W1": 10080, "MN1": 43200,
+}
+
+
+def _tf(timeframe: str) -> str:
+    tf = (timeframe or "").upper()
+    if tf not in _TF_MINUTES:
+        raise ValueError(f"Invalid timeframe: '{timeframe}'")
+    return tf
+
+
+def _parse_date(value: Optional[str]) -> Optional[datetime]:
+    if not value:
+        return None
+    ts = pd.to_datetime(value, utc=True)
+    return ts.to_pydatetime()
+
+
+def _inclusive_to(to_date):
+    """A bare YYYY-MM-DD `to` means 'through the END of that day' (MT5 history
+    semantics). The hosted API parses a date-only string to midnight, so a
+    same-day / from==to query filters closeTime <= 00:00:00 and returns EMPTY —
+    silently hiding that day's trades (audit §1). Bump a date-only `to` to
+    end-of-day so the whole day is included. Times-of-day are passed through
+    untouched. Returns a string (history passes strings to the SDK)."""
+    if not to_date:
+        return to_date
+    s = str(to_date).strip()
+    if len(s) == 10 and s.count("-") == 2 and "T" not in s and ":" not in s:
+        return s + "T23:59:59.999999"
+    return to_date
+
+
+# MT5 ENUM_SYMBOL_TRADE_MODE — surface a human label alongside the raw int so a
+# caller doesn't have to memorise the enum.
+_TRADE_MODE_DESC = {0: "DISABLED", 1: "LONGONLY", 2: "SHORTONLY", 3: "CLOSEONLY", 4: "FULL"}
+
+
+def _tick_freshness(tick) -> tuple:
+    """(age_seconds, stale) for a cached tick — stale past 60s so a bot can
+    reject a frozen weekend / closed-market quote (audit §14). Shared by both
+    get_symbol_price and the bid/ask embedded in get_symbol_info."""
+    ts = _parse_date(getattr(tick, "timestamp", None))
+    if ts is None:
+        return None, False
+    age = (datetime.now(timezone.utc) - ts).total_seconds()
+    return round(age, 1), age > 60.0
+
+
+# ── DataFrame builders (match the local-MT5 client's column shapes) ───────────
+
+def _positions_to_df(positions) -> pd.DataFrame:
+    if not positions:
+        return pd.DataFrame()
+    rows = [{
+        "ticket": p.ticket,
+        "time": p.open_time,
+        "type": p.side,                 # 'BUY' / 'SELL'
+        "magic": p.magic,
+        "volume": p.volume,
+        "price_open": p.entry_price,
+        "sl": p.stop_loss,
+        "tp": p.take_profit,
+        "price_current": p.current_price,
+        "swap": p.swap,
+        "commission": p.commission,
+        "profit": p.profit,
+        "symbol": p.symbol,
+        "comment": p.comment,
+    } for p in positions]
+    return pd.DataFrame(rows)
+
+
+def _pending_to_df(orders) -> pd.DataFrame:
+    if not orders:
+        return pd.DataFrame()
+    rows = [{
+        "ticket": o.ticket,
+        "time_setup": o.set_time,
+        "type": o.type,                 # BUY_LIMIT / SELL_STOP / ...
+        "symbol": o.symbol,
+        "volume": o.volume,
+        "price_open": o.price,
+        "sl": o.stop_loss,
+        "tp": o.take_profit,
+        "expiration": o.expiration_time,
+    } for o in orders]
+    return pd.DataFrame(rows)
+
+
+def _candles_to_df(candles) -> pd.DataFrame:
+    if not candles:
+        return pd.DataFrame()
+    df = pd.DataFrame([{
+        "time": c.timestamp,
+        "open": c.open,
+        "high": c.high,
+        "low": c.low,
+        "close": c.close,
+        # Real per-bar tick count + spread (ask−bid) when the SDK/API supplies
+        # them; getattr keeps this working against an older SDK that doesn't.
+        "tick_volume": int(getattr(c, "tick_volume", 0) or 0),
+        "spread": float(getattr(c, "spread", 0.0) or 0.0),
+    } for c in candles])
+    df["time"] = pd.to_datetime(df["time"], unit="s", utc=True)
+    return df.sort_values("time", ascending=False).reset_index(drop=True)
+
+
+def _history_to_df(trades) -> pd.DataFrame:
+    if not trades:
+        return pd.DataFrame()
+    rows = [{
+        "ticket": t.ticket,
+        "symbol": t.symbol,
+        "type": t.side,
+        "volume": t.volume,
+        "open_price": t.open_price,
+        "close_price": t.close_price,
+        "open_time": t.open_time,
+        "close_time": t.close_time,
+        # Coerce missing numerics to 0.0 (audit §2): the exit-deal leg of a
+        # round-trip can carry a blank profit, which a CSV consumer parsing
+        # `profit` as float would hit as NaN / an exception. (The degenerate
+        # zero-duration legs themselves are a server-side pairing concern.)
+        "profit": t.profit if t.profit is not None else 0.0,
+        "swap": t.swap if t.swap is not None else 0.0,
+        "commission": t.commission if t.commission is not None else 0.0,
+    } for t in trades]
+    # The hosted history can surface both constituent deals of a round-trip
+    # (entry + exit) as separate records that project to byte-identical rows.
+    # Drop only fully-identical rows — conservative, never removes a genuinely
+    # distinct trade.
+    return pd.DataFrame(rows).drop_duplicates().reset_index(drop=True)
+
+
+def _orders_to_df(orders) -> pd.DataFrame:
+    """One row per FILLED order (distinct from the deal/round-trip view)."""
+    if not orders:
+        return pd.DataFrame()
+    return pd.DataFrame([{
+        "order_ticket": o.order_ticket,
+        "symbol": o.symbol,
+        "type": o.side,
+        "volume": o.volume,
+        "price": o.price,
+        "time": o.time,
+        "position_id": o.position_id,
+        "state": o.state,
+        "deal_count": o.deal_count,
+    } for o in orders])
+
+
+def _ok(message: str, data: Any = None) -> Dict[str, Any]:
+    return {"error": False, "message": message, "data": data}
+
+
+def _err(message: str) -> Dict[str, Any]:
+    return {"error": True, "message": message, "data": None}
+
+
+# ── Sub-adapters ──────────────────────────────────────────────────────────────
+
+class _Account:
+    def __init__(self, owner: "TickerAllClient"):
+        self._o = owner
+
+    def _info(self):
+        return self._o._sdk.accounts.get(self._o._account_id).account
+
+    def get_account_info(self) -> Dict[str, Any]:
+        return self.get_trade_statistics()
+
+    def get_trade_statistics(self) -> Dict[str, Any]:
+        info = self._info()
+        if info is None:
+            return {"error": True, "message": "Account offline — connection is warming, retry shortly."}
+        equity = info.equity if info.equity is not None else info.balance
+        profit = (equity - info.balance) if equity is not None else 0.0
+        return {
+            "name": info.name,
+            "server": self._o._server,
+            "account_type": info.account_type,
+            "currency": info.currency,
+            "leverage": info.leverage,
+            "balance": info.balance,
+            "equity": equity,
+            "profit": profit,
+            "margin": info.margin,
+            "free_margin": info.free_margin,
+            "margin_level": info.margin_level,
+        }
+
+    # Full MT5Account surface (each derived from the account snapshot) so this is
+    # a faithful drop-in, not just the subset the MCP/HTTP tools currently call.
+    def get_balance(self) -> float:
+        i = self._info(); return float(i.balance) if i else 0.0
+
+    def get_equity(self) -> float:
+        i = self._info()
+        if not i:
+            return 0.0
+        return float(i.equity if i.equity is not None else i.balance)
+
+    def get_margin(self) -> float:
+        i = self._info(); return float(i.margin or 0.0) if i else 0.0
+
+    def get_free_margin(self) -> float:
+        i = self._info()
+        if not i:
+            return 0.0
+        return float(i.free_margin if i.free_margin is not None else i.balance)
+
+    def get_margin_level(self) -> float:
+        i = self._info(); return float(i.margin_level or 0.0) if i else 0.0
+
+    def get_currency(self) -> str:
+        i = self._info(); return (i.currency or "") if i else ""
+
+    def get_leverage(self) -> int:
+        i = self._info(); return int(i.leverage) if i else 0
+
+    def get_account_type(self) -> str:
+        i = self._info(); return (i.account_type or "") if i else ""
+
+    def is_trade_allowed(self) -> bool:
+        return self._o._connected
+
+    def check_margin_level(self, min_level: float = 100.0) -> bool:
+        ml = self.get_margin_level()
+        return ml >= min_level if ml else True
+
+
+class _Market:
+    def __init__(self, owner: "TickerAllClient"):
+        self._o = owner
+
+    def get_symbols(self, group: Optional[str] = None) -> List[str]:
+        symbols = self._o._sdk.accounts.symbols(self._o._account_id)
+        if group:
+            symbols = [s for s in symbols if fnmatch.fnmatch(s, group)]
+        return symbols
+
+    def get_symbol_price(self, symbol_name: str) -> Dict[str, Any]:
+        # Distinguish an UNKNOWN symbol from a known-but-closed market (audit §7)
+        # so a bot doesn't retry forever on a typo.
+        if not self._o._symbol_known(symbol_name):
+            raise RuntimeError(
+                f"Symbol '{symbol_name}' is not offered on this account "
+                f"(unknown symbol — not a closed market)."
+            )
+        tick = self._o._latest_tick(symbol_name)
+        age, stale = _tick_freshness(tick)
+        return {
+            "bid": tick.bid,
+            "ask": tick.ask,
+            "last": tick.bid,
+            "volume": 0,
+            "time": _parse_date(tick.timestamp) or datetime.now(timezone.utc),
+            # Freshness guard (audit §14): weekend / closed-market quotes are
+            # served with an honest timestamp but a frozen, non-tradeable ask
+            # (e.g. EURUSD with a ~1200-pip Friday-close spread). Surface the
+            # quote age + a `stale` flag so a 24/5 bot can refuse to trade on a
+            # frozen quote instead of buying far above the real bid.
+            "age_seconds": age,
+            "stale": stale,
+        }
+
+    def get_candles_latest(self, symbol_name: str, timeframe: str, count: int = 100) -> pd.DataFrame:
+        tf = _tf(timeframe)
+        # Tell an UNKNOWN symbol (typo / unsupported) apart from a known symbol
+        # with no bars in the window (audit §7) — otherwise a typo'd symbol
+        # silently returns an empty frame instead of erroring, exactly like
+        # get_symbol_price guards.
+        if not self._o._symbol_known(symbol_name):
+            raise RuntimeError(
+                f"Symbol '{symbol_name}' is not offered on this account "
+                f"(unknown symbol — not a closed market)."
+            )
+        # Translate "N bars" into a generous hours look-back, then take the most
+        # recent N. The 3x buffer + a floor absorb weekend/holiday gaps and reach
+        # far enough back to trigger the deep-history fetch, so a request still
+        # yields ~N bars even when the live resident window is shallow.
+        hours = max(72, int((count * _TF_MINUTES[tf] / 60) * 3) + 1)
+        candles = self._o._sdk.candles.get(self._o._account_id, symbol=symbol_name, hours=hours, timeframe=tf)
+        return _candles_to_df(candles).head(int(count))
+
+    def get_candles_by_date(self, symbol_name: str, timeframe: str,
+                            from_date: Optional[str] = None, to_date: Optional[str] = None) -> pd.DataFrame:
+        tf = _tf(timeframe)
+        # Unknown symbol -> error (not a silent empty frame), same guard as
+        # get_candles_latest / get_symbol_price (audit §7).
+        if not self._o._symbol_known(symbol_name):
+            raise RuntimeError(
+                f"Symbol '{symbol_name}' is not offered on this account "
+                f"(unknown symbol — not a closed market)."
+            )
+        frm = _parse_date(from_date)
+        to = _parse_date(_inclusive_to(to_date))  # date-only `to` = end of that day (audit §1)
+        now = datetime.now(timezone.utc)
+        span_start = frm or (now - pd.Timedelta(days=7).to_pytimedelta())
+        hours = max(1, int((now - span_start).total_seconds() / 3600) + 1)
+        candles = self._o._sdk.candles.get(self._o._account_id, symbol=symbol_name, hours=hours, timeframe=tf)
+        df = _candles_to_df(candles)
+        if df.empty:
+            return df
+        if frm is not None:
+            df = df[df["time"] >= pd.Timestamp(frm)]
+        if to is not None:
+            df = df[df["time"] <= pd.Timestamp(to)]
+        return df.reset_index(drop=True)
+
+    def get_symbol_info(self, symbol_name: str) -> Dict[str, Any]:
+        """Symbol spec (digits/point/contract/lot limits/trade mode) plus a live
+        bid/ask, keyed with MT5-style names. Raises if the symbol is unknown to
+        the account (no spec and no obtainable tick)."""
+        spec = self._o._symbol_spec(symbol_name)
+        tick = None
+        try:
+            # Match get_symbol_price's window (4s) so a known-but-closed market's
+            # frozen snapshot tick is surfaced here too, not dropped.
+            tick = self._o._latest_tick(symbol_name, timeout=4.0)
+        except Exception:  # noqa: BLE001
+            tick = None
+        if spec is None and tick is None:
+            raise RuntimeError(f"Symbol '{symbol_name}' not found on this account.")
+        info: Dict[str, Any] = {"name": symbol_name}
+        if spec is not None:
+            info.update({
+                "digits": spec.digits,
+                "point": spec.point,
+                "volume_min": spec.volume_min,
+                "volume_max": spec.volume_max,
+                "volume_step": spec.volume_step,
+                "trade_mode": spec.trade_mode,
+                "trade_mode_desc": _TRADE_MODE_DESC.get(spec.trade_mode, "UNKNOWN"),
+                "trade_contract_size": spec.contract_size,
+                "trade_tick_size": spec.tick_size,
+                "trade_tick_value": spec.tick_value,
+                "spec_source": spec.spec_source,
+            })
+        # ALWAYS emit bid/ask/age_seconds/stale so a caller can read info["bid"]
+        # unconditionally. A known-but-closed market used to omit them entirely
+        # (no tick within the window) -> info["bid"] KeyError'd consumers, while
+        # get_symbol_price returned the frozen quote with a stale flag. Now the
+        # keys are always present: a real or frozen tick -> its values + the same
+        # staleness signal as get_symbol_price; no obtainable tick -> nulls
+        # flagged stale, never dropped keys.
+        if tick is not None:
+            info["bid"] = tick.bid
+            info["ask"] = tick.ask
+            info["age_seconds"], info["stale"] = _tick_freshness(tick)
+        else:
+            info["bid"] = None
+            info["ask"] = None
+            info["age_seconds"] = None
+            info["stale"] = True
+        return info
+
+
+class _Order:
+    def __init__(self, owner: "TickerAllClient"):
+        self._o = owner
+
+    # — reads —
+    def get_all_positions(self) -> pd.DataFrame:
+        return _positions_to_df(self._o._positions())
+
+    def get_positions_by_symbol(self, symbol: str) -> pd.DataFrame:
+        return _positions_to_df([p for p in self._o._positions() if p.symbol == symbol])
+
+    def get_positions_by_id(self, id: Union[int, str]) -> pd.DataFrame:
+        return _positions_to_df([p for p in self._o._positions() if str(p.ticket) == str(id)])
+
+    def get_all_pending_orders(self) -> pd.DataFrame:
+        return _pending_to_df(self._o._pending())
+
+    def get_pending_orders_by_symbol(self, symbol: str) -> pd.DataFrame:
+        return _pending_to_df([o for o in self._o._pending() if o.symbol == symbol])
+
+    def get_pending_orders_by_id(self, id: Union[int, str]) -> pd.DataFrame:
+        return _pending_to_df([o for o in self._o._pending() if str(o.ticket) == str(id)])
+
+    # — writes —
+    def place_market_order(self, *, type: str, symbol: str, volume: Union[float, int]):
+        # Market orders stay FAIL-FAST (no queue_if_reconnecting): on a cold
+        # session the place fails cleanly rather than risk a fill at a stale
+        # price; the caller re-decides with fresh prices. Do NOT add
+        # queue_if_reconnecting here — it would queue-and-replay a price-
+        # sensitive order.
+        try:
+            r = self._o._sdk.orders.place(
+                self._o._account_id, type="market", symbol=symbol, side=type.upper(), volume=float(volume),
+            )
+            # The market result now carries the executed fill price directly
+            # (the hosted API returns it on the fill), so no position re-read is
+            # needed.
+            return _ok("Order sent successfully", _order_result_data(r))
+        except Exception as e:  # noqa: BLE001 — surface a clean message to the LLM
+            return _err(str(e))
+
+    def place_pending_order(self, *, type: str, symbol: str, volume: Union[float, int],
+                            price: Union[float, int], stop_loss: Optional[Union[float, int]] = 0.0,
+                            take_profit: Optional[Union[float, int]] = 0.0):
+        try:
+            kind = self._o._classify_pending(symbol, type.upper(), float(price))  # 'limit' | 'stop'
+            # Pending orders are price-insensitive → queue-and-replay on a cold/
+            # reconnecting session (the SDK reuses one idempotency key for the
+            # replay). This makes the write exactly-once and prevents the
+            # duplicate resting order a racy re-arm re-issue would create
+            # (audit CRITICAL-1).
+            r = self._o._sdk.orders.place(
+                self._o._account_id, type=kind, symbol=symbol, side=type.upper(), volume=float(volume),
+                price=float(price),
+                stop_loss=(float(stop_loss) if stop_loss else None),
+                take_profit=(float(take_profit) if take_profit else None),
+                queue_if_reconnecting=True,
+            )
+            return _ok("Order sent successfully", _order_result_data(r))
+        except Exception as e:  # noqa: BLE001
+            return _err(str(e))
+
+    def modify_position(self, id: Union[str, int], *, stop_loss: Optional[Union[int, float]] = None,
+                        take_profit: Optional[Union[int, float]] = None):
+        try:
+            self._o._sdk.positions.modify(
+                self._o._account_id, int(id),
+                stop_loss=(float(stop_loss) if stop_loss is not None else None),
+                take_profit=(float(take_profit) if take_profit is not None else None),
+                queue_if_reconnecting=True,  # idempotent by ticket → safe to replay (audit HIGH-3)
+            )
+            return _ok(f"Modify position {id} success")
+        except Exception as e:  # noqa: BLE001
+            return _err(str(e))
+
+    def modify_pending_order(self, *, id: Union[int, str], price: Optional[Union[int, float]] = None,
+                             stop_loss: Optional[Union[int, float]] = None,
+                             take_profit: Optional[Union[int, float]] = None):
+        try:
+            self._o._sdk.orders.modify_pending(
+                self._o._account_id, int(id),
+                price=(float(price) if price is not None else None),
+                stop_loss=(float(stop_loss) if stop_loss is not None else None),
+                take_profit=(float(take_profit) if take_profit is not None else None),
+                queue_if_reconnecting=True,  # idempotent by ticket → safe to replay
+            )
+            return _ok(f"Modify pending order {id} success")
+        except Exception as e:  # noqa: BLE001
+            return _err(str(e))
+
+    def close_position(self, id: Union[str, int]):
+        try:
+            # Idempotent by ticket → queue-and-replay on a cold session so a
+            # dropped ack on a write that actually applied doesn't surface as a
+            # false failure (audit HIGH-3 / TRADE_DROPPED).
+            self._o._sdk.positions.close(self._o._account_id, int(id), queue_if_reconnecting=True)
+            return _ok(f"Close position {id} success")
+        except Exception as e:  # noqa: BLE001
+            return _err(str(e))
+
+    def cancel_pending_order(self, id: Union[int, str]):
+        try:
+            self._o._sdk.orders.cancel_pending(self._o._account_id, int(id), queue_if_reconnecting=True)
+            return _ok(f"Cancel pending order {id} success")
+        except Exception as e:  # noqa: BLE001
+            return _err(str(e))
+
+    # — bulk —
+    def _close_positions(self, positions, label: str) -> Dict[str, Any]:
+        n = 0
+        for p in positions:
+            try:
+                self._o._sdk.positions.close(self._o._account_id, int(p.ticket), queue_if_reconnecting=True)
+                n += 1
+            except Exception:  # noqa: BLE001 — best-effort bulk close
+                pass
+        return _ok(f"Close {n} {label} success")
+
+    def close_all_positions(self):
+        return self._close_positions(self._o._positions(), "positions")
+
+    def close_all_positions_by_symbol(self, symbol: str):
+        return self._close_positions([p for p in self._o._positions() if p.symbol == symbol], f"{symbol} positions")
+
+    def close_all_profitable_positions(self):
+        return self._close_positions([p for p in self._o._positions() if (p.profit or 0) > 0], "profitable positions")
+
+    def close_all_losing_positions(self):
+        return self._close_positions([p for p in self._o._positions() if (p.profit or 0) < 0], "losing positions")
+
+    def cancel_all_pending_orders(self):
+        orders = self._o._pending()
+        n = 0
+        for o in orders:
+            try:
+                self._o._sdk.orders.cancel_pending(self._o._account_id, int(o.ticket), queue_if_reconnecting=True)
+                n += 1
+            except Exception:  # noqa: BLE001
+                pass
+        return _ok(f"Cancel {n} pending orders success")
+
+    def cancel_pending_orders_by_symbol(self, symbol: str):
+        orders = [o for o in self._o._pending() if o.symbol == symbol]
+        n = 0
+        for o in orders:
+            try:
+                self._o._sdk.orders.cancel_pending(self._o._account_id, int(o.ticket), queue_if_reconnecting=True)
+                n += 1
+            except Exception:  # noqa: BLE001
+                pass
+        return _ok(f"Cancel {n} {symbol} pending orders success")
+
+
+class _History:
+    def __init__(self, owner: "TickerAllClient"):
+        self._o = owner
+
+    def get_deals_as_dataframe(self, from_date: Optional[str] = None, to_date: Optional[str] = None,
+                               group: Optional[str] = None) -> pd.DataFrame:
+        trades = self._o._sdk.history.get(self._o._account_id, symbol=group,
+                                          from_=from_date, to=_inclusive_to(to_date))
+        return _history_to_df(trades)
+
+    def get_orders_as_dataframe(self, from_date: Optional[str] = None, to_date: Optional[str] = None,
+                                group: Optional[str] = None) -> pd.DataFrame:
+        """Filled-ORDER history (one row per filled order) — a real order log,
+        distinct from the round-trip DEAL view of get_deals, so a bot can
+        reconcile intent vs fills (audit §8/§3). Filled-only: cancelled/rejected/
+        expired orders aren't returned by the API. Falls back to the deal view on
+        an older SDK that doesn't expose the orders endpoint."""
+        orders_fn = getattr(getattr(self._o._sdk, "history", None), "orders", None)
+        if callable(orders_fn):
+            orders = orders_fn(self._o._account_id, symbol=group,
+                               from_=from_date, to=_inclusive_to(to_date))
+            return _orders_to_df(orders)
+        return self.get_deals_as_dataframe(from_date=from_date, to_date=to_date, group=group)
+
+
+def _order_result_data(r) -> Dict[str, Any]:
+    return {
+        "ticket": r.ticket, "symbol": r.symbol, "side": r.side, "type": r.type,
+        "volume": r.volume, "status": r.status, "price": r.price,
+        "stop_loss": r.stop_loss, "take_profit": r.take_profit,
+    }
+
+
+# ── Main client ───────────────────────────────────────────────────────────────
+
+class TickerAllClient:
+    """Drop-in alternative to ``MT5Client`` backed by a hosted MetaTrader API."""
+
+    def __init__(self, config: Optional[Dict[str, Any]] = None):
+        cfg = config or {}
+        self._api_key = cfg.get("api_key") or os.getenv("TICKERALL_API_KEY")
+        self._base_url = cfg.get("base_url") or os.getenv("TICKERALL_API_BASE_URL")
+        # Explicit WS stream URL, or derived from base_url at connect() so live
+        # ticks follow a custom (self-hosted / staging) host instead of prod.
+        self._stream_url = cfg.get("stream_url") or os.getenv("TICKERALL_STREAM_URL")
+        self._broker = cfg.get("broker") or os.getenv("TICKERALL_BROKER", "mt5")
+        self._server = cfg.get("server")
+        self._account = cfg.get("account") or cfg.get("login")
+        self._password = cfg.get("password")
+
+        self._sdk = None
+        self._account_id: Optional[str] = None
+        self._connected = False
+
+        # Live tick stream. The SDK maintains the latest-tick cache and the
+        # per-symbol subscription state itself (wait_for_tick), so the adapter
+        # no longer keeps its own tick dict / subscribed set.
+        self._stream = None
+        self._spec_cache: Optional[Dict[str, Any]] = None
+        self._spec_cache_at: float = 0.0
+        self._symbols_cache: Optional[set] = None
+        self._symbols_cache_at: float = 0.0
+        # Re-fetch the symbol/spec maps after this TTL (and on every reconnect)
+        # so a refreshed catalog — a hosted-service redeploy or a broker spec
+        # change — is picked up without restarting the process. Previously these were
+        # cached once-and-forever, so a session that outlived a catalog change
+        # served stale specs (e.g. a derived volume_min) until a manual restart.
+        self._spec_cache_ttl: float = 300.0
+        self._lock = threading.Lock()
+
+        self.account = _Account(self)
+        self.market = _Market(self)
+        self.order = _Order(self)
+        self.history = _History(self)
+
+    # — connection —
+    def connect(self) -> bool:
+        if not self._api_key:
+            raise ConnectionError("TICKERALL_API_KEY is required for the hosted provider.")
+        try:
+            from tickerall import Tickerall
+        except ImportError as e:  # pragma: no cover
+            raise ConnectionError(
+                "The 'tickerall' package is required for the hosted provider. Install it with: pip install tickerall"
+            ) from e
+
+        kwargs: Dict[str, Any] = {"api_key": self._api_key}
+        if self._base_url:
+            kwargs["base_url"] = self._base_url
+        # Only override the WS stream URL when one is explicitly set (env).
+        # Otherwise the SDK derives it from base_url (http→ws, https→wss), so a
+        # custom / staging host streams ticks from itself, not the prod default.
+        if self._stream_url:
+            kwargs["stream_url"] = self._stream_url
+        self._sdk = Tickerall(**kwargs)
+
+        if not (self._server and self._account and self._password):
+            raise ConnectionError("Hosted provider needs server, account (login) and password to open a session.")
+
+        # keep_alive caches the credentials in this process (never persisted) so
+        # the connection transparently re-arms if it later goes cold — e.g. across
+        # a broker drop or a hosted-side restart. The next tool call after a cold
+        # auto-reconnects, so a long-running MCP/HTTP server self-heals without a
+        # manual reconnect. (A local MT5 terminal has no equivalent.)
+        result = self._sdk.sessions.keep_alive(
+            broker=self._broker, server=self._server,
+            account=int(self._account), password=self._password,
+        )
+        self._account_id = result.account_id
+        self._connected = True
+        # A (re)connect may bring a refreshed catalog (hosted-service redeploy /
+        # broker spec change), so drop the cached symbol/spec maps — they
+        # re-populate lazily from the fresh session.
+        self._spec_cache = None
+        self._symbols_cache = None
+        return True
+
+    def disconnect(self) -> bool:
+        self._connected = False
+        if self._stream is not None:
+            try:
+                self._stream.close()
+            except Exception:  # noqa: BLE001
+                pass
+            self._stream = None
+        # End the hosted session (also drops the kept credentials). Best-effort —
+        # if it fails, the session simply cools on its own TTL.
+        if self._sdk is not None and self._account_id is not None:
+            try:
+                self._sdk.sessions.end(self._account_id)
+            except Exception:  # noqa: BLE001
+                pass
+        return True
+
+    def is_connected(self) -> bool:
+        return self._connected
+
+    def get_terminal_info(self) -> Dict[str, Any]:
+        return {"provider": "tickerall", "server": self._server, "account_id": self._account_id}
+
+    def get_version(self):
+        return (5, 0, 0, 0)
+
+    def last_error(self):
+        return (0, "no error")
+
+    # — internals —
+    def _require_online(self):
+        """Fetch the account snapshot and FAIL LOUD if the broker connection is
+        still warming/offline. Without this guard, position / pending reads
+        return an empty list during the ~90s cold-start window — which is
+        indistinguishable from a genuinely flat account. A bot polling at
+        startup or right after a reconnect would then see 'no positions' when
+        the truth is UNKNOWN, and could open a duplicate or skip stop-loss
+        management (audit BLOCKER §3). `get_account_info` already errors in this
+        state via `info is None`; the read paths must be consistent."""
+        snap = self._sdk.accounts.get(self._account_id)
+        if snap.account is None or getattr(snap, "status", "online") != "online":
+            raise RuntimeError(
+                "Account is warming/offline — broker position state is UNKNOWN "
+                "(not flat). Retry shortly; do not treat an empty read as "
+                "'no positions'."
+            )
+        return snap
+
+    def _positions(self):
+        return self._require_online().positions
+
+    def _pending(self):
+        self._require_online()
+        return self._sdk.orders.list_pending(self._account_id)
+
+    def _symbol_known(self, name: str) -> bool:
+        """True if the symbol is offered on this account. Lets callers tell an
+        UNKNOWN symbol (typo / unsupported) apart from a known-but-closed
+        market (audit §7) — the two must not return the same error, or a bot
+        retries forever on a symbol that will never exist."""
+        now = time.monotonic()
+        if self._symbols_cache is None or (now - self._symbols_cache_at) > self._spec_cache_ttl:
+            try:
+                self._symbols_cache = set(self._sdk.accounts.symbols(self._account_id))
+                self._symbols_cache_at = now
+            except Exception:  # noqa: BLE001
+                # Keep any prior set on a transient refresh failure (only fall
+                # back to empty on the first fetch); back off a TTL before retry.
+                if self._symbols_cache is None:
+                    self._symbols_cache = set()
+                self._symbols_cache_at = now
+        return name in self._symbols_cache
+
+    def _symbol_spec(self, name: str):
+        """Look up one symbol's spec, caching the account's full spec list on
+        first use (it's effectively static for a session)."""
+        now = time.monotonic()
+        if self._spec_cache is None or (now - self._spec_cache_at) > self._spec_cache_ttl:
+            try:
+                specs = self._sdk.accounts.symbol_specs(self._account_id)
+                self._spec_cache = {s.name: s for s in specs}
+                self._spec_cache_at = now
+            except Exception:  # noqa: BLE001
+                # Keep the prior spec map on a transient refresh failure (only
+                # fall back to empty on the first fetch); back off a TTL.
+                if self._spec_cache is None:
+                    self._spec_cache = {}
+                self._spec_cache_at = now
+        return self._spec_cache.get(name)
+
+    def _ensure_stream(self):
+        if self._stream is not None:
+            return
+        with self._lock:
+            if self._stream is not None:
+                return
+            # The SDK stream maintains the latest-tick cache itself — no
+            # on("tick") wiring needed here.
+            self._stream = self._sdk.stream.connect()
+
+    def _latest_tick(self, symbol: str, timeout: float = 4.0):
+        self._ensure_stream()
+        # wait_for_tick subscribes the symbol if needed (a no-op once subscribed,
+        # and it re-subscribes correctly on a fresh stream after a reconnect),
+        # caches inbound ticks, and blocks up to `timeout` for the first one.
+        try:
+            return self._stream.wait_for_tick(symbol, account_id=self._account_id, timeout=timeout)
+        except TimeoutError as e:
+            # Preserve the RuntimeError contract get_symbol_price / get_symbol_info
+            # rely on (a closed market with no tick reads as "no price").
+            raise RuntimeError(
+                f"No price received for '{symbol}' (no recent tick — market may be closed)."
+            ) from e
+
+    def _classify_pending(self, symbol: str, side: str, price: float) -> str:
+        """Map a (side, price) pending order to a 'limit' or 'stop' relative to
+        the current market — the broker semantics MT5 infers automatically."""
+        try:
+            tick = self._latest_tick(symbol, timeout=4.0)
+        except Exception:
+            return "limit"
+        if side == "BUY":
+            return "limit" if price < tick.ask else "stop"
+        return "limit" if price > tick.bid else "stop"

--- a/src/metatrader_mcp/server.py
+++ b/src/metatrader_mcp/server.py
@@ -86,6 +86,12 @@ def get_symbol_price(ctx: Context, symbol_name: str) -> dict:
 	return client.market.get_symbol_price(symbol_name=symbol_name)
 
 @mcp.tool()
+def get_symbol_info(ctx: Context, symbol_name: str) -> dict:
+	"""Get the full symbol specification: digits, point, volume min/max/step, contract size, tick size, tick value, trade mode, plus the latest bid/ask. Needed to size orders and convert a stop distance to risk currency."""
+	client = get_client(ctx)
+	return client.market.get_symbol_info(symbol_name=symbol_name)
+
+@mcp.tool()
 def get_all_symbols(ctx: Context) -> list:
 	"""Get a list of all available market symbols."""
 	client = get_client(ctx)
@@ -122,6 +128,8 @@ def get_positions_by_id(ctx: Context, id: Union[int, str]) -> list:
 	"""Get open positions by ID."""
 	client = get_client(ctx)
 	df = client.order.get_positions_by_id(id=id)
+	if hasattr(df, 'empty') and df.empty:
+		return f"No open position with id {id}."
 	return df.to_csv() if hasattr(df, 'to_csv') else str(df)
 
 @mcp.tool()
@@ -143,6 +151,8 @@ def get_pending_orders_by_id(ctx: Context, id: Union[int, str]) -> list:
 	"""Get pending orders by id."""
 	client = get_client(ctx)
 	df = client.order.get_pending_orders_by_id(id=id)
+	if hasattr(df, 'empty') and df.empty:
+		return f"No pending order with id {id}."
 	return df.to_csv() if hasattr(df, 'to_csv') else str(df)
 
 @mcp.tool()

--- a/src/metatrader_mcp/utils.py
+++ b/src/metatrader_mcp/utils.py
@@ -1,6 +1,11 @@
+from __future__ import annotations
+
 import os
 from typing import Any, Optional, Union
-from metatrader_client import client
+# NOTE: `metatrader_client.client` (the local-MT5 path) is imported lazily inside
+# init() so this module — and the MCP server — import cleanly on Linux/macOS when
+# the hosted provider is used (MetaTrader5 is Windows-only). `from __future__
+# import annotations` keeps the type hints below from needing it at import time.
 
 
 def resolve_transport_config(transport=None, host=None, port=None):
@@ -29,7 +34,7 @@ def init(
 	password: Optional[str],
 	server: Optional[str],
 	path: Optional[str] = None,
-) -> Optional[client.MT5Client]:
+) -> Optional[Any]:
 	"""
 	Initialize MT5Client
 
@@ -40,10 +45,30 @@ def init(
 		path (Optional[str]): Path to MT5 terminal executable (default: None for auto-detect)
 
 	Returns:
-		Optional[client.MT5Client]: MT5Client instance if all parameters are provided, None otherwise
+		Optional[Any]: MT5Client instance if all parameters are provided, None otherwise
 	"""
 
+	# Opt-in hosted provider: when TICKERALL_API_KEY is set, route through a
+	# hosted MetaTrader API instead of a local MT5 terminal — so the server runs
+	# on Linux / macOS / anywhere, no terminal to install or babysit. A literal
+	# no-op when the env var is unset (the local-MT5 path below is untouched).
+	if os.getenv("TICKERALL_API_KEY"):
+		from metatrader_client.tickerall_client import TickerAllClient
+		tk_client = TickerAllClient({
+			"api_key": os.getenv("TICKERALL_API_KEY"),
+			"base_url": os.getenv("TICKERALL_API_BASE_URL"),
+			"broker": os.getenv("TICKERALL_BROKER", "mt5"),
+			"server": server,
+			"account": login,
+			"password": password,
+		})
+		tk_client.connect()
+		return tk_client
+
 	if login and password and server:
+		# Lazy import — pulls in MetaTrader5 (Windows-only) only on the local path.
+		from metatrader_client import client
+
 		config = {
 			"login": int(login),
 			"password": password,
@@ -60,5 +85,5 @@ def init(
 
 	return None
 	
-def get_client(ctx: Any) -> Optional[client.MT5Client]:
+def get_client(ctx: Any) -> Optional[Any]:
 	return ctx.request_context.lifespan_context.client

--- a/tests/test_tickerall_client.py
+++ b/tests/test_tickerall_client.py
@@ -1,0 +1,496 @@
+"""
+Offline tests for the optional hosted (TickerAll) provider.
+
+These inject a fake SDK + fake response objects (SimpleNamespace), so they need
+only pandas — no network, no live account, and no `tickerall` install. They lock
+in the MT5-compatible shapes the MCP tools consume (DataFrame columns, the
+{error, message, data} order-result envelope, the symbol filter, bulk closes).
+"""
+from types import SimpleNamespace
+
+import pandas as pd
+import pytest
+
+from metatrader_client.tickerall_client import TickerAllClient
+
+
+def _position(**kw):
+    base = dict(ticket=1, symbol="BTCUSDm", side="BUY", volume=0.10, stop_loss=0.0,
+                take_profit=0.0, magic=0, comment="", swap=0.0, commission=0.0,
+                open_time="2026-06-05T10:00:00Z", entry_price=62000.0, current_price=62100.0,
+                profit=10.0, last_update=None)
+    base.update(kw)
+    return SimpleNamespace(**base)
+
+
+def _candle(ts, o, h, l, c, tick_volume=5, spread=0.5):
+    return SimpleNamespace(timestamp=ts, open=o, high=h, low=l, close=c, bid=c,
+                           tick_volume=tick_volume, spread=spread)
+
+
+def _horder(**kw):
+    base = dict(order_ticket="9001", symbol="BTCUSDm", side="BUY", volume=0.1,
+                price=62000.0, time="2026-06-05T10:00:00Z", position_id="9001",
+                state="FILLED", deal_count=1)
+    base.update(kw)
+    return SimpleNamespace(**base)
+
+
+class _Recorder:
+    """Captures the last call's kwargs so tests can assert the mapping."""
+    def __init__(self):
+        self.calls = []
+
+    def __call__(self, *args, **kwargs):
+        self.calls.append((args, kwargs))
+        return SimpleNamespace(ticket=999, symbol=kwargs.get("symbol", ""), side=kwargs.get("side", ""),
+                               type=kwargs.get("type", ""), volume=kwargs.get("volume", 0.0),
+                               status="open", price=kwargs.get("price"), stop_loss=None, take_profit=None)
+
+
+def _spec(**kw):
+    base = dict(name="BTCUSDm", volume_min=0.01, volume_max=100.0, volume_step=0.01,
+                spec_source="broker", trade_mode=4, digits=2, point=0.01, tick_size=0.01,
+                contract_size=1.0, tick_value=0.01)
+    base.update(kw)
+    return SimpleNamespace(**base)
+
+
+class _FakeStream:
+    """Stand-in for the SDK's TickerallStream. `_ensure_stream` short-circuits
+    when `c._stream` is set, and `_latest_tick` delegates to `wait_for_tick`, so
+    a test just seeds the per-symbol ticks here (no real WebSocket)."""
+    def __init__(self, ticks=None):
+        self._ticks = dict(ticks or {})
+
+    def wait_for_tick(self, symbol, *, account_id=None, timeout=4.0):
+        tick = self._ticks.get(symbol)
+        if tick is None:
+            raise TimeoutError(f"no tick for {symbol}")
+        return tick
+
+    def latest_tick(self, symbol):
+        return self._ticks.get(symbol)
+
+    def close(self):
+        pass
+
+
+def _client_with_sdk(positions=None, pending=None, candles=None, symbols=None, specs=None, warming=False):
+    c = TickerAllClient({"api_key": "x", "server": "S", "account": 1, "password": "p"})
+    c._account_id = "acc1"
+    c._connected = True
+    place = _Recorder()
+    closed, cancelled = [], []
+    # Default symbol universe so `_symbol_known` (the §7 unknown-vs-closed guard)
+    # passes for the common symbols the tests price; pass `symbols=` to override.
+    sym_list = symbols if symbols is not None else ["BTCUSDm", "ETHUSDm", "EURUSDm", "XAUUSDm"]
+
+    def _snapshot(account_id, **k):
+        if warming:
+            # Cold-start window: broker state not yet known → account is None,
+            # status offline. Reads must error, not report flat (audit §3).
+            return SimpleNamespace(positions=[], account=None, status="offline")
+        return SimpleNamespace(
+            positions=list(positions or []), status="online",
+            account=SimpleNamespace(name="Demo", account_type="demo", currency="USD", leverage=500,
+                                    balance=1000.0, equity=1010.0, margin=5.0, free_margin=1005.0,
+                                    margin_level=200.0),
+        )
+
+    sdk = SimpleNamespace(
+        accounts=SimpleNamespace(
+            symbols=lambda account_id, **k: list(sym_list),
+            symbol_specs=lambda account_id, **k: list(specs or []),
+            get=_snapshot,
+        ),
+        orders=SimpleNamespace(
+            list_pending=lambda account_id, **k: list(pending or []),
+            place=place,
+            cancel_pending=lambda account_id, ticket, **k: cancelled.append(ticket),
+        ),
+        positions=SimpleNamespace(
+            close=lambda account_id, ticket, **k: closed.append(ticket),
+            modify=lambda account_id, ticket, **k: None,
+        ),
+        candles=SimpleNamespace(get=lambda account_id, **k: list(candles or [])),
+        history=SimpleNamespace(get=lambda account_id, **k: [], orders=lambda account_id, **k: []),
+    )
+    c._sdk = sdk
+    return c, place, closed, cancelled
+
+
+def test_positions_dataframe_has_mt5_columns():
+    c, *_ = _client_with_sdk(positions=[_position(ticket=11), _position(ticket=22, side="SELL")])
+    df = c.order.get_all_positions()
+    assert len(df) == 2
+    for col in ("ticket", "type", "volume", "price_open", "sl", "tp", "price_current", "profit", "symbol"):
+        assert col in df.columns
+    assert set(df["type"]) == {"BUY", "SELL"}
+
+
+def test_get_positions_by_symbol_and_id_filter():
+    c, *_ = _client_with_sdk(positions=[_position(ticket=11, symbol="BTCUSDm"),
+                                        _position(ticket=22, symbol="EURUSDm")])
+    assert list(c.order.get_positions_by_symbol("EURUSDm")["ticket"]) == [22]
+    assert list(c.order.get_positions_by_id(11)["ticket"]) == [11]
+    assert c.order.get_positions_by_symbol("XAUUSDm").empty
+
+
+def test_place_market_order_maps_to_sdk_and_wraps_result():
+    c, place, *_ = _client_with_sdk()
+    res = c.order.place_market_order(type="buy", symbol="BTCUSDm", volume=0.5)
+    assert res["error"] is False and res["data"]["ticket"] == 999
+    _, kwargs = place.calls[-1]
+    assert kwargs["type"] == "market" and kwargs["side"] == "BUY" and kwargs["volume"] == 0.5
+
+
+def test_place_market_order_error_is_caught():
+    c, *_ = _client_with_sdk()
+    def boom(*a, **k):
+        raise RuntimeError("broker rejected")
+    c._sdk.orders.place = boom
+    res = c.order.place_market_order(type="BUY", symbol="BTCUSDm", volume=0.1)
+    assert res["error"] is True and "broker rejected" in res["message"]
+
+
+def test_close_all_positions_iterates_every_ticket():
+    c, _place, closed, _ = _client_with_sdk(positions=[_position(ticket=11), _position(ticket=22), _position(ticket=33)])
+    res = c.order.close_all_positions()
+    assert res["error"] is False and sorted(closed) == [11, 22, 33]
+
+
+def test_close_all_profitable_only_closes_winners():
+    c, _place, closed, _ = _client_with_sdk(positions=[_position(ticket=11, profit=5.0),
+                                                       _position(ticket=22, profit=-3.0)])
+    c.order.close_all_profitable_positions()
+    assert closed == [11]
+
+
+def test_get_symbols_group_filter():
+    c, *_ = _client_with_sdk(symbols=["BTCUSDm", "EURUSDm", "EURGBPm", "EURJPYm"])
+    assert c.market.get_symbols() == ["BTCUSDm", "EURUSDm", "EURGBPm", "EURJPYm"]
+    # *USD* keeps the two USD pairs; EUR/GBP and EUR/JPY are excluded.
+    assert c.market.get_symbols(group="*USD*") == ["BTCUSDm", "EURUSDm"]
+    assert c.market.get_symbols(group="EUR*") == ["EURUSDm", "EURGBPm", "EURJPYm"]
+
+
+def test_candles_dataframe_shape_and_sort():
+    c, *_ = _client_with_sdk(candles=[_candle(1000, 1, 2, 0.5, 1.5, tick_volume=7, spread=0.3),
+                                      _candle(4600, 1.5, 2.5, 1, 2.0, tick_volume=12, spread=0.4)])
+    df = c.market.get_candles_latest("BTCUSDm", "H1", 10)
+    assert list(df.columns) == ["time", "open", "high", "low", "close", "tick_volume", "spread"]
+    # newest first
+    assert df.iloc[0]["close"] == 2.0
+    # real tick_volume + spread surfaced (audit §4: were hardcoded 0 / absent)
+    assert df.iloc[0]["tick_volume"] == 12 and df.iloc[0]["spread"] == pytest.approx(0.4)
+    assert str(df["time"].dtype).startswith("datetime64")
+
+
+def test_get_orders_uses_real_order_log_distinct_from_deals():
+    # Audit §8: get_orders must hit the real FILLED-order log, not alias deals.
+    c, *_ = _client_with_sdk()
+    c._sdk.history = SimpleNamespace(
+        get=lambda account_id, **k: [_trade()],   # the deal view
+        orders=lambda account_id, **k: [_horder(order_ticket="9001"), _horder(order_ticket="9002")],
+    )
+    df = c.history.get_orders_as_dataframe()
+    assert list(df["order_ticket"]) == ["9001", "9002"]
+    assert "order_ticket" in df.columns and "position_id" in df.columns
+
+
+def test_get_orders_falls_back_to_deals_on_older_sdk():
+    # Graceful fallback: an SDK without history.orders → the deal view (no crash).
+    c, *_ = _client_with_sdk()
+    c._sdk.history = SimpleNamespace(get=lambda account_id, **k: [_trade(ticket="111")])
+    df = c.history.get_orders_as_dataframe()
+    assert list(df["ticket"]) == ["111"]
+
+
+def test_place_market_order_surfaces_fill_price_from_result():
+    # Audit §4 closed: the market result now carries the executed fill price
+    # directly (the hosted API returns it on the fill), so the adapter passes it
+    # through and does NOT re-read the position.
+    c, *_ = _client_with_sdk(positions=[_position(ticket=999, entry_price=62050.0)])
+    # Simulate the hosted API returning the fill price on the market result.
+    c._sdk.orders.place = lambda account_id, **k: SimpleNamespace(
+        ticket=999, symbol=k.get("symbol", ""), side=k.get("side", ""), type=k.get("type", ""),
+        volume=k.get("volume", 0.0), status="open", price=1632.5, stop_loss=None, take_profit=None)
+    res = c.order.place_market_order(type="BUY", symbol="ETHUSDm", volume=0.1)
+    # Returns the RESULT's fill price (1632.5), not the position's entry (62050).
+    assert res["error"] is False and res["data"]["price"] == 1632.5
+
+
+def test_account_trade_statistics_shape():
+    c, *_ = _client_with_sdk()
+    info = c.account.get_trade_statistics()
+    for k in ("balance", "equity", "profit", "margin_level", "free_margin", "account_type", "leverage", "currency"):
+        assert k in info
+    assert info["account_type"] == "demo"
+    assert info["profit"] == pytest.approx(10.0)  # equity 1010 - balance 1000
+
+
+def test_get_symbol_price_reads_tick_cache():
+    c, *_ = _client_with_sdk()
+    # Inject a fake stream whose wait_for_tick returns a cached tick (no real WS).
+    c._stream = _FakeStream({"BTCUSDm": SimpleNamespace(bid=62000.0, ask=62010.0, timestamp="2026-06-05T10:00:00Z")})
+    price = c.market.get_symbol_price("BTCUSDm")
+    assert price["bid"] == 62000.0 and price["ask"] == 62010.0 and price["last"] == 62000.0
+
+
+def test_get_symbol_info_maps_spec_and_tick():
+    c, *_ = _client_with_sdk(specs=[_spec(name="BTCUSDm", volume_min=0.01, volume_step=0.01, digits=2)])
+    c._stream = _FakeStream({"BTCUSDm": SimpleNamespace(bid=62000.0, ask=62010.0, timestamp="2026-06-05T10:00:00Z")})
+    info = c.market.get_symbol_info("BTCUSDm")
+    assert info["name"] == "BTCUSDm"
+    for k in ("digits", "point", "volume_min", "volume_max", "volume_step", "trade_mode",
+              "trade_contract_size", "trade_tick_size", "trade_tick_value", "bid", "ask"):
+        assert k in info
+    assert info["bid"] == 62000.0 and info["volume_step"] == 0.01
+
+
+def test_get_symbol_info_embeds_quote_freshness():
+    # Re-audit nit: the bid/ask embedded in get_symbol_info must carry the same
+    # stale flag as get_symbol_price, so a caller can't mistake a frozen weekend
+    # quote for a live one.
+    c, *_ = _client_with_sdk(specs=[_spec(name="EURUSDm", digits=5)], symbols=["EURUSDm"])
+    c._stream = _FakeStream({"EURUSDm": SimpleNamespace(bid=1.152, ask=1.164, timestamp="2026-06-04T20:57:00Z")})
+    info = c.market.get_symbol_info("EURUSDm")
+    assert info["stale"] is True and info["age_seconds"] > 60
+
+
+def test_get_symbol_info_includes_trade_mode_label():
+    # Polish: surface a human label next to the raw ENUM_SYMBOL_TRADE_MODE int.
+    c, *_ = _client_with_sdk(specs=[_spec(name="BTCUSDm", trade_mode=4)], symbols=["BTCUSDm"])
+    c._stream = _FakeStream({"BTCUSDm": SimpleNamespace(bid=1.0, ask=1.1, timestamp="2026-06-05T10:00:00Z")})
+    info = c.market.get_symbol_info("BTCUSDm")
+    assert info["trade_mode"] == 4 and info["trade_mode_desc"] == "FULL"
+
+
+def test_get_symbol_info_unknown_symbol_raises():
+    # No spec and the fake SDK has no stream, so the tick fetch fails fast → raise.
+    c, *_ = _client_with_sdk(specs=[])
+    import pytest as _pt
+    with _pt.raises(Exception):
+        c.market.get_symbol_info("FOOBARm")
+
+
+def test_get_symbol_info_always_emits_price_keys_even_with_no_tick():
+    # A known-but-closed market with no obtainable tick used to DROP bid/ask/
+    # stale entirely, so a caller reading info["bid"] hit a KeyError (while
+    # get_symbol_price returned a frozen quote + stale flag). The keys must now
+    # always be present: nulls flagged stale rather than omitted.
+    c, *_ = _client_with_sdk(specs=[_spec(name="XAUUSDm", digits=3)], symbols=["XAUUSDm"])
+    def _no_tick(symbol, timeout=4.0):
+        raise RuntimeError("No price received (market may be closed).")
+    c._latest_tick = _no_tick  # _Market reads self._o._latest_tick
+    info = c.market.get_symbol_info("XAUUSDm")
+    assert info["digits"] == 3 and info["trade_mode_desc"] == "FULL"  # spec still served
+    for k in ("bid", "ask", "age_seconds", "stale"):
+        assert k in info  # never dropped
+    assert info["bid"] is None and info["ask"] is None and info["stale"] is True
+
+
+def test_get_candles_latest_unknown_symbol_raises_not_empty():
+    # Audit §7 parity: a typo'd / unsupported symbol must ERROR (like
+    # get_symbol_price), not silently return an empty frame.
+    c, *_ = _client_with_sdk(symbols=["BTCUSDm", "ETHUSDm"])
+    with pytest.raises(RuntimeError, match="unknown symbol"):
+        c.market.get_candles_latest("NOTAREALSYMBOLm", "H1", 10)
+    # a known symbol with no bars in the window stays a (legitimate) empty frame
+    assert c.market.get_candles_latest("BTCUSDm", "H1", 10).empty
+
+
+def test_get_candles_by_date_unknown_symbol_raises():
+    c, *_ = _client_with_sdk(symbols=["BTCUSDm"])
+    with pytest.raises(RuntimeError, match="unknown symbol"):
+        c.market.get_candles_by_date("NOPEm", "H1", from_date="2026-06-01")
+
+
+def test_spec_cache_refreshes_not_cached_once_forever():
+    # ETHUSDm-derived-spec staleness fix: the spec cache must refresh on
+    # reconnect (connect() clears it) and after a TTL, so a refreshed catalog
+    # (hosted-service redeploy / broker spec change) is picked up without a
+    # restart — not cached once-and-forever like before.
+    import time as _t
+    c, *_ = _client_with_sdk(specs=[_spec(name="ETHUSDm", volume_min=0.01)])
+    assert c._symbol_spec("ETHUSDm").volume_min == 0.01            # first fetch (stale/derived min)
+    # broker refresh: the SDK now returns the corrected spec
+    c._sdk.accounts.symbol_specs = lambda account_id, **k: [_spec(name="ETHUSDm", volume_min=0.1)]
+    assert c._symbol_spec("ETHUSDm").volume_min == 0.01            # within TTL, no reconnect -> still cached
+    c._spec_cache = None                                           # reconnect clears it (connect() does this)
+    assert c._symbol_spec("ETHUSDm").volume_min == 0.1            # -> re-fetches the corrected min
+    # TTL path: re-stale + expire the timestamp -> re-fetch
+    c._spec_cache = {"ETHUSDm": _spec(name="ETHUSDm", volume_min=0.01)}
+    c._spec_cache_at = _t.monotonic() - c._spec_cache_ttl - 1
+    assert c._symbol_spec("ETHUSDm").volume_min == 0.1
+
+
+def test_spec_cache_keeps_prior_on_transient_refresh_failure():
+    # A blip during a TTL refresh must NOT blank a working cache.
+    import time as _t
+    c, *_ = _client_with_sdk(specs=[_spec(name="ETHUSDm", volume_min=0.1)])
+    assert c._symbol_spec("ETHUSDm").volume_min == 0.1
+    def _boom(*a, **k): raise RuntimeError("hosted API blip")
+    c._sdk.accounts.symbol_specs = _boom
+    c._spec_cache_at = _t.monotonic() - c._spec_cache_ttl - 1      # force a refresh attempt
+    assert c._symbol_spec("ETHUSDm").volume_min == 0.1             # prior spec preserved, not blanked
+
+
+def test_disconnect_ends_session_and_closes_stream():
+    c = TickerAllClient({"api_key": "x", "server": "S", "account": 1, "password": "p"})
+    c._account_id = "acc1"; c._connected = True
+    ended, closed = [], []
+    c._sdk = SimpleNamespace(sessions=SimpleNamespace(end=lambda aid, **k: ended.append(aid)))
+    c._stream = SimpleNamespace(close=lambda: closed.append(True))
+    assert c.disconnect() is True
+    assert ended == ["acc1"] and closed == [True]
+    assert c._connected is False and c._stream is None
+
+
+def test_account_full_surface():
+    c, *_ = _client_with_sdk()  # fake account: balance 1000, equity 1010, margin 5, free 1005, ml 200, lev 500
+    assert c.account.get_balance() == 1000.0
+    assert c.account.get_equity() == 1010.0
+    assert c.account.get_margin() == 5.0
+    assert c.account.get_free_margin() == 1005.0
+    assert c.account.get_margin_level() == 200.0
+    assert c.account.get_currency() == "USD"
+    assert c.account.get_leverage() == 500
+    assert c.account.get_account_type() == "demo"
+    assert c.account.is_trade_allowed() is True
+    assert c.account.check_margin_level(100.0) is True
+
+
+def _trade(**kw):
+    base = dict(ticket="111", symbol="ETHUSDm", side="SELL", volume=0.01, open_price=60748.35,
+                close_price=60864.65, open_time="t1", close_time="t2", profit=-1.163, swap=0.0, commission=0.0)
+    base.update(kw)
+    return SimpleNamespace(**base)
+
+
+def test_queue_if_reconnecting_on_idempotent_ops_but_not_market():
+    # The at-least-once safety fix: price-insensitive / idempotent writes
+    # queue-and-replay on a cold session; market orders stay fail-fast.
+    c = TickerAllClient({"api_key": "x", "server": "S", "account": 1, "password": "p"})
+    c._account_id = "acc1"; c._connected = True
+    captured = {}
+    def rec(name):
+        def f(*a, **k):
+            captured[name] = k
+            return SimpleNamespace(ticket=1, symbol="BTCUSDm", side="BUY", type="market",
+                                   volume=0.1, status="open", price=None, stop_loss=None, take_profit=None)
+        return f
+    # _classify_pending needs a tick — inject a fake stream that returns one.
+    c._stream = _FakeStream({"BTCUSDm": SimpleNamespace(bid=100.0, ask=101.0, timestamp="t")})
+    c._sdk = SimpleNamespace(
+        orders=SimpleNamespace(place=rec("place"), cancel_pending=rec("cancel"), modify_pending=rec("modpend")),
+        positions=SimpleNamespace(close=rec("close"), modify=rec("modpos")),
+    )
+    c.order.place_market_order(type="BUY", symbol="BTCUSDm", volume=0.1)
+    assert captured["place"].get("queue_if_reconnecting") in (None, False)  # market = fail-fast
+    c.order.place_pending_order(type="BUY", symbol="BTCUSDm", volume=0.1, price=99.0)  # below ask → limit
+    assert captured["place"].get("queue_if_reconnecting") is True           # pending = queued
+    c.order.close_position(5);          assert captured["close"].get("queue_if_reconnecting") is True
+    c.order.cancel_pending_order(5);    assert captured["cancel"].get("queue_if_reconnecting") is True
+    c.order.modify_position(5, stop_loss=90.0);   assert captured["modpos"].get("queue_if_reconnecting") is True
+    c.order.modify_pending_order(id=5, price=98.0); assert captured["modpend"].get("queue_if_reconnecting") is True
+
+
+def test_history_drops_only_identical_duplicate_rows():
+    from metatrader_client.tickerall_client import _history_to_df
+    a = _trade()
+    # the same round-trip surfaced twice (entry + exit deals project identically) -> one row
+    assert len(_history_to_df([a, a])) == 1
+    # a genuinely distinct trade is kept
+    b = _trade(ticket="222", symbol="BTCUSDm", side="BUY", volume=0.05, profit=5.0)
+    df = _history_to_df([a, a, b])
+    assert len(df) == 2
+    assert set(df["ticket"]) == {"111", "222"}
+
+
+def test_to_date_is_inclusive_of_the_whole_day():
+    # Audit §1: a bare YYYY-MM-DD `to` (esp. a same-day from==to query) must
+    # cover the whole day, not filter to midnight and silently return empty.
+    from metatrader_client.tickerall_client import _inclusive_to
+    assert _inclusive_to("2026-06-06") == "2026-06-06T23:59:59.999999"
+    assert _inclusive_to("2026-06-06T12:30:00") == "2026-06-06T12:30:00"  # time given → untouched
+    assert _inclusive_to(None) is None
+    # and the deals path passes the bumped `to` through to the SDK
+    captured = {}
+    c, *_ = _client_with_sdk()
+    c._sdk.history = SimpleNamespace(get=lambda account_id, **k: captured.update(k) or [])
+    c.history.get_deals_as_dataframe(from_date="2026-06-06", to_date="2026-06-06")
+    assert captured["to"] == "2026-06-06T23:59:59.999999" and captured["from_"] == "2026-06-06"
+
+
+def test_stream_url_passthrough_lets_sdk_derive():
+    # The provider no longer derives the WS URL itself — the SDK derives it from
+    # base_url (http→ws / https→wss + /v1/stream; covered by the SDK's own tests).
+    # The provider only forwards an explicit TICKERALL_STREAM_URL override; with
+    # none set, _stream_url is None so connect() doesn't pass stream_url and the
+    # SDK derives it from base_url.
+    import os
+    c = TickerAllClient({"api_key": "x", "base_url": "http://localhost:3100"})
+    assert c._stream_url is None
+    # explicit TICKERALL_STREAM_URL wins (forwarded verbatim to the SDK).
+    os.environ["TICKERALL_STREAM_URL"] = "wss://custom/v1/stream"
+    try:
+        c2 = TickerAllClient({"api_key": "x", "base_url": "http://localhost:3100"})
+        assert c2._stream_url == "wss://custom/v1/stream"
+    finally:
+        del os.environ["TICKERALL_STREAM_URL"]
+
+
+def test_reads_raise_during_warming_instead_of_reporting_flat():
+    # Audit BLOCKER §3: during the cold-start window, position/pending reads must
+    # ERROR (state unknown), not silently return an empty "flat" frame. Otherwise
+    # a bot polling at startup opens a duplicate or skips stop-loss management.
+    c, *_ = _client_with_sdk(warming=True)
+    with pytest.raises(RuntimeError, match="warming"):
+        c.order.get_all_positions()
+    with pytest.raises(RuntimeError, match="warming"):
+        c.order.get_all_pending_orders()
+    # The account read already errors gracefully (returns an envelope, not raise).
+    info = c.account.get_trade_statistics()
+    assert info.get("error") is True
+    # And once online, an empty position list is a legitimate "flat" (no raise).
+    c2, *_ = _client_with_sdk(positions=[])
+    assert c2.order.get_all_positions().empty
+
+
+def test_get_symbol_price_unknown_symbol_is_distinct_from_closed_market():
+    # Audit §7: a typo / unsupported symbol must not return the same "no recent
+    # tick — market may be closed" error as a real-but-closed symbol.
+    c, *_ = _client_with_sdk(symbols=["BTCUSDm", "ETHUSDm"])
+    with pytest.raises(RuntimeError, match="unknown symbol"):
+        c.market.get_symbol_price("NOTAREALSYMBOLm")
+
+
+def test_get_symbol_price_flags_stale_weekend_quote():
+    # Audit §14: a frozen Friday-close quote must be flagged stale so a 24/5 bot
+    # can refuse it. A fresh quote must not be flagged.
+    from datetime import datetime, timezone
+    c, *_ = _client_with_sdk(symbols=["ETHUSDm"])
+    stream = _FakeStream()
+    c._stream = stream
+    # Stale: a 2-day-old tick.
+    stream._ticks["ETHUSDm"] = SimpleNamespace(bid=1561.0, ask=1700.0, timestamp="2026-06-04T20:57:00Z")
+    stale = c.market.get_symbol_price("ETHUSDm")
+    assert stale["stale"] is True and stale["age_seconds"] is not None and stale["age_seconds"] > 60
+    # Fresh: a tick stamped ~now.
+    stream._ticks["ETHUSDm"] = SimpleNamespace(bid=1561.0, ask=1561.5,
+                                               timestamp=datetime.now(timezone.utc).isoformat())
+    fresh = c.market.get_symbol_price("ETHUSDm")
+    assert fresh["stale"] is False
+
+
+def test_history_coerces_blank_profit_to_zero():
+    # Audit §2: an exit-deal leg can carry a blank profit/swap/commission; coerce
+    # to 0.0 so a CSV consumer parsing float doesn't hit NaN / an exception.
+    from metatrader_client.tickerall_client import _history_to_df
+    leg = _trade(ticket="333", profit=None, swap=None, commission=None)
+    df = _history_to_df([leg])
+    assert df.iloc[0]["profit"] == 0.0
+    assert df.iloc[0]["swap"] == 0.0
+    assert df.iloc[0]["commission"] == 0.0


### PR DESCRIPTION
## Summary

Adds an **optional, opt-in hosted provider** so the MCP server can run on **Linux/macOS without a local MetaTrader 5 terminal**. Instead of a Windows machine with a running terminal, point the server at a hosted MetaTrader API ([TickerAll](https://tickerall.com)) by adding a single env var (your broker login is supplied exactly as it is today). When the var is unset, nothing changes - the existing local `MetaTrader5` path is completely untouched.

Closes #32. Related: #29.

## Why

The `MetaTrader5` Python package isn't a standalone library — it's an IPC client to a **running MetaTrader 5 desktop terminal on the same machine**. Three pain points fall out of that, and the hosted provider removes all three for anyone who opts in:

1. **You can't even install the package outside Windows today.** `MetaTrader5` ships Windows-only wheels and is a hard dependency, so `pip install metatrader-mcp-server` *fails at install time* on Linux/macOS.

2. **The local path needs a GUI MT5 terminal running and logged in at all times.** If the terminal crashes, logs out, or auto-updates, the server goes dark — it can't run as a clean headless service. It's a very fragile solution and not scalable.

3. **MT5 terminal allows only 1 account at a time**. Hosted solution supports multiple accounts at once, but requires additional updates to current MCP server.

## Design — additive & opt-in

- Selected by a single env var, `TICKERALL_API_KEY`; a literal no-op when unset.
- The local-MT5 code path is **unchanged** — zero behavior change for existing users.
- Both servers (MCP + HTTP/OpenAPI) share the same `init()` factory, so neither needs provider-specific code.

## What's added

| File | Change |
|---|---|
| `metatrader_client/tickerall_client.py` | `TickerAllClient`, mirroring the `MT5Client` surface (account / market / order / history + live ticks) |
| `metatrader_mcp/utils.py` | `init()` returns the hosted client when the key is set; lazy `MetaTrader5` import otherwise |
| `metatrader_client/__init__.py` | graceful import on Linux/macOS |
| `metatrader_mcp/server.py` | registers `get_symbol_info` (full symbol spec) |
| `pyproject.toml` | Windows-only `MetaTrader5` marker + a `hosted` extra |
| `README.md` | hosted-provider section + Linux/macOS note |

## Tests

`tests/test_tickerall_client.py` — 32 offline tests (fake SDK, mocks only; no network, no live account, no `MetaTrader5`).

## Try it

```bash
pip install "metatrader-mcp-server[hosted]"
```

The only new variable vs. the local setup is `TICKERALL_API_KEY` — your broker `login` / `password` / `server` are supplied exactly as they are today:

```bash
export TICKERALL_API_KEY=...          # your hosted-API key, from https://tickerall.com

metatrader-mcp-server \
  --login 12345678 \
  --password YOUR_BROKER_PASSWORD \
  --server YourBroker-Server          # runs on Linux/macOS — no terminal to install or keep open
```

You will need to obtain an API key from https://tickerall.com - it's free!


